### PR TITLE
Add Named Error Bag

### DIFF
--- a/src/Http/Requests/StoreSubscriberRequest.php
+++ b/src/Http/Requests/StoreSubscriberRequest.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StoreSubscriberRequest extends FormRequest
 {
+
+    protected $errorBag = 'subscribers';
+
     /**
      * Get the validation rules that apply to the request.
      *


### PR DESCRIPTION
This is helpful if you have several forms on one page (e.g. newsletter registration in the footer and a contact form). 

Caution: I'm not sure. But that could be a problem with existing code. However, I think it would be very useful. Maybe you have a better idea?